### PR TITLE
Reformat VERSION.txt in YAML.

### DIFF
--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -18,7 +18,7 @@ namespace Deployotron {
         'SiteOffline',
         'BackupDatabase',
         'DeployCode',
-        'CreateVersionTxt',
+        'CreateVersionYaml',
         'RestartApache2',
         'UpdateDatabase',
         'RunDrakePostUpdate',
@@ -1084,14 +1084,14 @@ namespace Deployotron\Actions {
   }
 
   /**
-   * Create a VERSION.txt file.
+   * Create a VERSION.yml file.
    */
-  class CreateVersionTxt extends Action {
-    static protected $description = 'Create VERSION.txt.';
-    static protected $runMessage = 'Creating VERSION.txt';
-    static protected $short = 'create VERSION.txt';
-    static protected $killSwitch = 'no-create-version-txt';
-    static protected $versionTxt = NULL;
+  class CreateVersionYaml extends Action {
+    static protected $description = 'Create VERSION.yml.';
+    static protected $runMessage = 'Creating VERSION.yml';
+    static protected $short = 'create VERSION.yml';
+    static protected $killSwitch = 'no-create-version-yml';
+    static protected $versionYaml = NULL;
 
     /**
      * {@inheritdoc}
@@ -1102,30 +1102,30 @@ namespace Deployotron\Actions {
         $this->shLocal('git tag --points-at ' . $state['deployed_sha']);
         $tags = implode(', ', $this->shOutputArray());
 
-        $version_txt = array();
-        $version_txt[] = 'Deployment info';
-        $version_txt[] = '---------------';
+        $version_yml = array();
+        $version_yml[] = '# Deployment info';
+        $version_yml[] = '';
         if (!empty($state['requested_branch'])) {
-          $version_txt[] = 'Branch: ' . $state['requested_branch'];
+          $version_yml[] = '- Branch: ' . $state['requested_branch'];
         }
         if (!empty($tags)) {
-          $version_txt[] = 'Tags: ' . $tags;
+          $version_yml[] = '- Tags: ' . $tags;
         }
-        $version_txt[] = 'SHA: ' . $state['deployed_sha'];
-        $version_txt[] = 'Time of deployment: ' . date('r');
-        $version_txt[] = 'Deployer: ' . $_SERVER['USER'] . '@' . php_uname('n');
+        $version_yml[] = '- SHA: ' . $state['deployed_sha'];
+        $version_yml[] = '- Time of deployment: ' . date('r');
+        $version_yml[] = '- Deployer: ' . $_SERVER['USER'] . '@' . php_uname('n');
 
-        // Delete any pre-existing VERSION.txt file and create a new one.
-        $this->sh('rm VERSION.txt');
+        // Delete any pre-existing VERSION.yml file and create a new one.
+        $this->sh('rm VERSION.yml');
         // You'd think that echo would do the job, but it's not consistent
         // across shells. Bash and most /bin/echo requires the -n option to
         // expand \n to a newline, while /bin/sh built-in echo doesn't and
         // prints the -n as part of the output. But printf works the same and is
         // POSIX 7, which should cover our bases.
-        $this->sh('printf ' . escapeshellarg(implode("\\n", $version_txt) . "\\n") . ' > VERSION.txt');
+        $this->sh('printf ' . escapeshellarg(implode("\\n", $version_yml) . "\\n") . ' > VERSION.yml');
       }
       else {
-        drush_log(dt('No version deployed, not creating/updating VERSION.txt.'), 'warning');
+        drush_log(dt('No version deployed, not creating/updating VERSION.yml.'), 'warning');
       }
       return TRUE;
     }

--- a/tests/deployotronTest.php
+++ b/tests/deployotronTest.php
@@ -210,8 +210,8 @@ class DeployotronCase extends Drush_CommandTestCase {
     $this->assertRegExp('/More than one of branch\\/tag\\/sha specified, using sha./', $this->getOutput());
     $this->assertRegExp('/HEAD now at 04256b5992d8b4a4fae25c7cb7888583749fabc0/', $this->getOutput());
 
-    // Check that VERSION.txt was created.
-    $this->assertFileExists($this->deploySite() . '/VERSION.txt');
+    // Check that VERSION.yml was created.
+    $this->assertFileExists($this->deploySite() . '/VERSION.yml');
 
     // Check that a invalid tag/branch prints the proper error message.
     $this->drush('deploy 2>&1', array('@deployotron'), array(
@@ -260,17 +260,17 @@ class DeployotronCase extends Drush_CommandTestCase {
       ), NULL, $this->webroot());
     $this->assertRegExp('/HEAD now at b9471948c3f83a665dd4f106aba3de8962d69b42/', $this->getOutput());
 
-    // VERSION.txt should still exist.
-    $this->assertFileExists($this->deploySite() . '/VERSION.txt');
+    // VERSION.yml should still exist.
+    $this->assertFileExists($this->deploySite() . '/VERSION.yml');
     // Check content.
-    $version_txt = file_get_contents($this->deploySite() . '/VERSION.txt');
-    $this->assertRegExp('/Deployment info/', $version_txt);
-    $this->assertRegExp('/SHA: b9471948c3f83a665dd4f106aba3de8962d69b42/', $version_txt);
-    $this->assertRegExp('/Time of deployment: /', $version_txt);
-    $this->assertRegExp('/Deployer: /', $version_txt);
+    $version_yml = file_get_contents($this->deploySite() . '/VERSION.yml');
+    $this->assertRegExp('/Deployment info/', $version_yml);
+    $this->assertRegExp('/SHA: b9471948c3f83a665dd4f106aba3de8962d69b42/', $version_yml);
+    $this->assertRegExp('/Time of deployment: /', $version_yml);
+    $this->assertRegExp('/Deployer: /', $version_yml);
 
     // Check that the switch for echo didn't got written to the file.
-    $this->assertNotRegExp('/-e/', $version_txt);
+    $this->assertNotRegExp('/-e/', $version_yml);
 
     // Check that a file in the way of a new file will cause the deployment to
     // roll back.
@@ -290,9 +290,9 @@ class DeployotronCase extends Drush_CommandTestCase {
     unlink($this->deploySite() . '/sites/all/modules/coffee');
     $this->drush('deploy 2>&1', array('@deployotron'), array('y' => TRUE), NULL, $this->webroot());
     $this->assertRegExp('/HEAD now at fbcaa29d45716edcbedc3c325bfbab828f1ce838/', $this->getOutput());
-    $version_txt = file_get_contents($this->deploySite() . '/VERSION.txt');
-    $this->assertRegExp('/Branch: master/', $version_txt);
-    $this->assertRegExp('/SHA: fbcaa29d45716edcbedc3c325bfbab828f1ce838/', $version_txt);
+    $version_yml = file_get_contents($this->deploySite() . '/VERSION.yml');
+    $this->assertRegExp('/Branch: master/', $version_yml);
+    $this->assertRegExp('/SHA: fbcaa29d45716edcbedc3c325bfbab828f1ce838/', $version_yml);
   }
 
   /**
@@ -462,7 +462,7 @@ class DeployotronCase extends Drush_CommandTestCase {
   /**
    * Test no-deploy.
    *
-   * And that Flowdock and VERSION.txt prints the appropriate message.
+   * And that Flowdock and VERSION.yml prints the appropriate message.
    */
   public function testNoDeploy() {
     $this->writeAlias(array(
@@ -480,8 +480,8 @@ class DeployotronCase extends Drush_CommandTestCase {
         'no-deploy' => TRUE,
         'flowdock-token' => $this->flowdockToken,
       ), NULL, $this->webroot());
-    // Check VERSION.txt message.
-    $this->assertRegExp('/No version deployed, not creating\/updating VERSION.txt/', $this->getOutput());
+    // Check VERSION.yml message.
+    $this->assertRegExp('/No version deployed, not creating\/updating VERSION.yml/', $this->getOutput());
 
     // Check Flowdock message.
     $this->assertRegExp('/No version deployed, not sending Flowdock notification/', $this->getOutput());

--- a/tests/deployotronTest.php
+++ b/tests/deployotronTest.php
@@ -269,9 +269,6 @@ class DeployotronCase extends Drush_CommandTestCase {
     $this->assertRegExp('/Time of deployment: /', $version_yml);
     $this->assertRegExp('/Deployer: /', $version_yml);
 
-    // Check that the switch for echo didn't got written to the file.
-    $this->assertNotRegExp('/-e/', $version_yml);
-
     // Check that a file in the way of a new file will cause the deployment to
     // roll back.
     file_put_contents($this->deploySite() . '/sites/all/modules/coffee', 'stuff');


### PR DESCRIPTION
With this small change the format of VERSION.txt will actually be YAML.

I think that would be useful for easier parsing of the file.

@danquah, will this break something for IDA?
