### PR TITLE
Use clean(er) Flowdock tags.

### DIFF
--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -1166,7 +1166,7 @@ namespace Deployotron\Actions {
           'from_address' => 'deployotron@reload.dk',
           'subject' => $subject,
           'content' => $body,
-          'tags' => array('deployotron', $this->site['#name']),
+          'tags' => array('deployotron', $this->getFlowdockTag()),
         );
         $data = json_encode($data);
 
@@ -1192,6 +1192,13 @@ namespace Deployotron\Actions {
         drush_log(dt('No version deployed, not sending Flowdock notification.'), 'warning');
       }
       return TRUE;
+    }
+
+    /**
+     * Get a Flowdock tag for the site.
+     */
+    private function getFlowdockTag() {
+      return preg_replace('/[^[:alnum:]_\-]/', '_', $this->site['#name']);
     }
   }
 


### PR DESCRIPTION
Flowdock does not accept tags with `.` in them which a site name usually will do.

This pull request tries to replace some of the "illegal" characters with an underscore.