### PR TITLE
Feature/fra

### DIFF
--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -20,6 +20,7 @@ namespace Deployotron {
         'DeployCode',
         'CreateVersionTxt',
         'RestartApache2',
+        'FeaturesRevertAll',
         'UpdateDatabase',
         'RunDrakePostUpdate',
         'ClearCache',

--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -965,10 +965,9 @@ namespace Deployotron\Actions {
   }
 
   /**
-  * Revert all features.
-  */
-  class FeaturesRevertAll extends Action
-  {
+   * Revert all features.
+   */
+  class FeaturesRevertAll extends Action {
     static protected $description = 'Revert all features.';
     static protected $runMessage = 'Reverting all features';
     static protected $enableSwitch = 'fra';

--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -965,6 +965,38 @@ namespace Deployotron\Actions {
   }
 
   /**
+  * Revert all features.
+  */
+  class FeaturesRevertAll extends Action
+  {
+    static protected $description = 'Revert all features.';
+    static protected $runMessage = 'Reverting all features';
+    static protected $enableSwitch = 'fra';
+    static protected $short = 'revert all features';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate() {
+      // This still prints output unless backend_options is set to FALSE.
+      if (!$this->drush('fra', array(), array('quiet' => TRUE, 'no' => TRUE))) {
+        return FALSE;
+      }
+      return TRUE;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run($state) {
+      if (!$this->drush('fra', array(), array('yes' => TRUE))) {
+        return drush_set_error(dt('Error reverting all features.'));
+      }
+      return TRUE;
+    }
+  }
+
+  /**
    * Update database.
    */
   class UpdateDatabase extends Action {


### PR DESCRIPTION
Hi - I had a use case for reverting all features before an updb and cc all. I'm not sure if the contrib space fits into the scope of the project. No worries if not.

One issue in the validate methond is that 'fra' still outputs messages unless drush_invoke_process sets backend_options to FALSE. The 'drush' method on Action would have to allow overriding that. Or maybe the validate method is overkill altogether.

Thanks.
-Rick