### PR TITLE
Feature/backend options

### DIFF
--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -408,6 +408,8 @@ namespace Deployotron {
      *   Command arguments.
      * @param string $options
      *   Command arguments.
+     * @param bool $backend_options
+     *   Backend options for drush_invoke_process().
      *
      * @return bool
      *   Whether the command succeeded.

--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -414,8 +414,8 @@ namespace Deployotron {
      * @return bool
      *   Whether the command succeeded.
      */
-    protected function drush($command, $args = array(), $options = array()) {
-      $this->drushResult = drush_invoke_process($this->site, $command, $args, $options, TRUE);
+    protected function drush($command, $args = array(), $options = array(), $backend_options = TRUE) {
+      $this->drushResult = drush_invoke_process($this->site, $command, $args, $options, $backend_options);
       if (!$this->drushResult || $this->drushResult['error_status'] != 0) {
         return FALSE;
       }

--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -979,9 +979,8 @@ namespace Deployotron\Actions {
      * {@inheritdoc}
      */
     public function validate() {
-      // This still prints output unless backend_options is set to FALSE.
-      if (!$this->drush('fra', array(), array('quiet' => TRUE, 'no' => TRUE))) {
-        return FALSE;
+      if (!$this->drush('fra', array(), array('quiet' => TRUE, 'no' => TRUE), FALSE)) {
+        return drush_set_error(dt("The drush command 'fra' could not be found."));
       }
       return TRUE;
     }

--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -980,7 +980,11 @@ namespace Deployotron\Actions {
      */
     public function validate() {
       if (!$this->drush('fra', array(), array('quiet' => TRUE, 'no' => TRUE), FALSE)) {
-        return drush_set_error(dt("The drush command 'fra' could not be found."));
+        foreach ($this->drushResult['error_log'] as $error) {
+          foreach ($error as $error_type => $message) {
+            drush_set_error($message);
+          }
+        }
       }
       return TRUE;
     }


### PR DESCRIPTION
The 'fra' validatation function added in #34 prints unnecessary messages before a deployment is run, ex. 'Current state matches defaults, aborting.'

The only way to prevent those messages from printing, to my knowledge, is to specify $backend_options as FALSE in drush_invoke_process. This PR makes the $backend_options argument optional in the drush method but defaults it to TRUE for backwards compatibility. 