### PR TITLE
Make error message a little easier to understand

### DIFF
--- a/deployotron.actions.inc
+++ b/deployotron.actions.inc
@@ -677,7 +677,7 @@ namespace Deployotron\Actions {
       // if they fail.
       if (!$this->sh('git diff-files --quiet --ignore-submodules --')) {
         if ($this->shRc() != 129) {
-          return drush_set_error(dt('Repository not clean.'));
+          return drush_set_error(dt('Remote git checkout not clean.'));
         }
         $fallback = TRUE;
       }
@@ -695,7 +695,7 @@ namespace Deployotron\Actions {
         }
         $output = trim($this->shOutput());
         if (!empty($output)) {
-          return drush_set_error(dt('Repository not clean.'));
+          return drush_set_error(dt('Remote git checkout not clean.'));
         }
       }
 

--- a/tests/deployotronTest.php
+++ b/tests/deployotronTest.php
@@ -244,7 +244,7 @@ class DeployotronCase extends Drush_CommandTestCase {
     // Check that a dirty checkout makes deployment fail..
     file_put_contents($this->deploySite() . '/index.php', 'stuff');
     $this->drush('deploy 2>&1', array('@deployotron'), array('y' => TRUE), NULL, $this->webroot(), self::EXIT_ERROR);
-    $this->assertRegExp('/Repository not clean/', $this->getOutput());
+    $this->assertRegExp('/Remote git checkout not clean/', $this->getOutput());
 
     // Check that a dirty checkout makes deployment fail, even if added to git.
     exec('cd ' . $this->deploySite() . ' && git add -u');


### PR DESCRIPTION
When the git checkout on the remote has overrides, it is now clearer
that it is the remote and that it is the folder checked out - not the
repository itself.